### PR TITLE
Add manual install of build essential package

### DIFF
--- a/containers/agdmhs/Dockerfile
+++ b/containers/agdmhs/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Andrew Gainer-Dewar, Ph.D. <andrew.gainer.dewar@gmail.com>
 # Add any algorithm dependencies here
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+    build-essential \
     libboost-log-dev \
     libboost-program-options-dev \
     libboost-system-dev \

--- a/containers/agdmhs/Dockerfile
+++ b/containers/agdmhs/Dockerfile
@@ -3,6 +3,9 @@ FROM algorun/algorun:latest
 MAINTAINER Andrew Gainer-Dewar, Ph.D. <andrew.gainer.dewar@gmail.com>
 
 # Add any algorithm dependencies here
+## VERY HACKY. Do not recommend.
+RUN touch /etc/apt/apt.conf.d/99verify-peer.conf \
+    && echo >>/etc/apt/apt.conf.d/99verify-peer.conf "Acquire { https::Verify-Peer false }"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     build-essential \


### PR DESCRIPTION
For `make`, `g++`, etc. which are required. Without this, the build step fails at `make`